### PR TITLE
Modified Unit-tests so that they always report scores using '.' as decimal separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+### This is a fork of [brateval](https://github.com/READ-BioMed/brateval).
+
 # BRAT-Eval v0.3.2
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,12 @@
       <version>${junit-jupiter.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.opencsv</groupId>
+      <artifactId>opencsv</artifactId>
+      <version>5.9</version>
+    </dependency>
   </dependencies>
 
     <distributionManagement>

--- a/src/main/java/au/com/nicta/csp/brateval/CompareEntities.java
+++ b/src/main/java/au/com/nicta/csp/brateval/CompareEntities.java
@@ -55,9 +55,9 @@ public class CompareEntities {
             if (nextLine != null) { //Until end
                 if (nextLine.length == 7 && !nextLine[0].equals("")){
                     if(nextLine[0].equals("all")){
-                        output.append("MicroPrecision: " +nextLine[precisionPos] +"\n");
-                        output.append("MicroRecall: " +nextLine[recallPos] +"\n");
-                        output.append("MicroF1: " +nextLine[f1Pos] +"\n");
+                        output.append("Task2aMicroP: " +nextLine[precisionPos] +"\n");
+                        output.append("Task2aMicroR: " +nextLine[recallPos] +"\n");
+                        output.append("Task2aMicroF1: " +nextLine[f1Pos] +"\n");
 
                         //System.out.println("MicroP=" +nextLine[precisionPos]);
                         //System.out.println("MicroR=" +nextLine[recallPos]);
@@ -72,9 +72,9 @@ public class CompareEntities {
                 }
             }
         }
-        output.append("MacroPrecision: " +String.format("%1.4f",macroPrecisionScores.stream().mapToDouble(var -> var).average().getAsDouble()) +"\n");
-        output.append("MacroRecall: " +String.format("%1.4f",macroRecallScores.stream().mapToDouble(var -> var).average().getAsDouble())+"\n");
-        output.append("MacroF1: " +String.format("%1.4f",macroF1Scores.stream().mapToDouble(var -> var).average().getAsDouble())+"\n");
+        output.append("Task2aMacroP: " +String.format("%1.4f",macroPrecisionScores.stream().mapToDouble(var -> var).average().getAsDouble()) +"\n");
+        output.append("Task2aMacroR: " +String.format("%1.4f",macroRecallScores.stream().mapToDouble(var -> var).average().getAsDouble())+"\n");
+        output.append("Task2aMacroF1: " +String.format("%1.4f",macroF1Scores.stream().mapToDouble(var -> var).average().getAsDouble())+"\n");
 
         //System.out.println("MacroP=" +String.format("%1.4f",macroPrecisionScores.stream().mapToDouble(var -> var).average().getAsDouble()));
         //System.out.println("MacroR=" +String.format("%1.4f",macroRecallScores.stream().mapToDouble(var -> var).average().getAsDouble()));

--- a/src/main/java/au/com/nicta/csp/brateval/CompareEntities.java
+++ b/src/main/java/au/com/nicta/csp/brateval/CompareEntities.java
@@ -27,6 +27,7 @@ public class CompareEntities {
 
         String evalFolder = Options.common.evalFolder;
         String goldFolder = Options.common.goldFolder;
+        String outFolder = Options.common.outputFolder;
 
         System.out.println("Evaluating Folder: " + evalFolder + " against Gold Folder: " + goldFolder + " Match settings : " + Options.common.matchType.toString());
 
@@ -46,7 +47,7 @@ public class CompareEntities {
         List<Double> macroRecallScores = new ArrayList<>();
         List<Double> macroF1Scores = new ArrayList<>();
 
-        FileWriter output = new FileWriter("scores.txt");
+        FileWriter output = new FileWriter(outFolder +File.separator +"scores.txt");
 
         CSVReader reader = new CSVReader(new StringReader(out.toString()));
         String[] nextLine;
@@ -72,7 +73,7 @@ public class CompareEntities {
             }
         }
         output.append("MacroPrecision: " +String.format("%1.4f",macroPrecisionScores.stream().mapToDouble(var -> var).average().getAsDouble()) +"\n");
-        output.append("MacroRevall: " +String.format("%1.4f",macroRecallScores.stream().mapToDouble(var -> var).average().getAsDouble())+"\n");
+        output.append("MacroRecall: " +String.format("%1.4f",macroRecallScores.stream().mapToDouble(var -> var).average().getAsDouble())+"\n");
         output.append("MacroF1: " +String.format("%1.4f",macroF1Scores.stream().mapToDouble(var -> var).average().getAsDouble())+"\n");
 
         //System.out.println("MacroP=" +String.format("%1.4f",macroPrecisionScores.stream().mapToDouble(var -> var).average().getAsDouble()));

--- a/src/main/java/au/com/nicta/csp/brateval/CompareEntities.java
+++ b/src/main/java/au/com/nicta/csp/brateval/CompareEntities.java
@@ -18,6 +18,7 @@ public class CompareEntities {
     static TaxonomyConfig taxonomy = TaxonomyConfig.singleton();
 
     public static void main(String argc[]) throws Exception {
+        Locale.setDefault(new Locale("en", "US")); //Reported scores use "." as decimal seperator
         Options.common = new Options(argc);
         verbose_output = Options.common.verbose;
         taxonomy.readConfigFile(Options.common.configFile);

--- a/src/main/java/au/com/nicta/csp/brateval/CompareRelations.java
+++ b/src/main/java/au/com/nicta/csp/brateval/CompareRelations.java
@@ -20,7 +20,8 @@ public class CompareRelations
 
 	public static void main (String argc []) throws Exception
 	{
-		Options.common = new Options(argc);
+        Locale.setDefault(new Locale("en", "US")); //Reported scores use "." as decimal seperator
+        Options.common = new Options(argc);
 		verbose_output = Options.common.verbose;
 		taxonomy = new TaxonomyConfig(Options.common.configFile);
 		show_full_taxonomy = Options.common.show_full_taxonomy;

--- a/src/main/java/au/com/nicta/csp/brateval/CompareRelations.java
+++ b/src/main/java/au/com/nicta/csp/brateval/CompareRelations.java
@@ -19,7 +19,9 @@ public class CompareRelations
     static  boolean show_full_taxonomy = false;
 	static  TaxonomyConfig taxonomy = TaxonomyConfig.singleton();
 
-	public static void main (String argc []) throws Exception
+    static String outFolder;
+
+    public static void main (String argc []) throws Exception
 	{
         Locale.setDefault(new Locale("en", "US")); //Reported scores use "." as decimal seperator
         Options.common = new Options(argc);
@@ -29,8 +31,9 @@ public class CompareRelations
 		
 		String evalFolder = Options.common.evalFolder;
 		String goldFolder = Options.common.goldFolder;
+        outFolder = Options.common.outputFolder;
 
-		System.out.println("Evaluating Folder: " + evalFolder + " against Gold Folder: " + goldFolder + " Match settings : " + Options.common.matchType.toString() );
+        System.out.println("Evaluating Folder: " + evalFolder + " against Gold Folder: " + goldFolder + " Match settings : " + Options.common.matchType.toString() );
 		evaluate(goldFolder, evalFolder, Options.common.matchType);
     }
     
@@ -313,7 +316,7 @@ public class CompareRelations
         List<Double> macroRecallScores = new ArrayList<>();
         List<Double> macroF1Scores = new ArrayList<>();
 
-        FileWriter output = new FileWriter("scores.txt");
+        FileWriter output = new FileWriter(outFolder +File.separator +"scores.txt");
         String[] nextLine;
         CSVReader reader = new CSVReader(new StringReader(out.toString()));
         while ((nextLine = reader.readNext()) != null) {
@@ -341,7 +344,7 @@ public class CompareRelations
         }
 
         output.append("MacroPrecision: " +String.format("%1.4f",macroPrecisionScores.stream().mapToDouble(var -> var).average().getAsDouble()) +"\n");
-        output.append("MacroRevall: " +String.format("%1.4f",macroRecallScores.stream().mapToDouble(var -> var).average().getAsDouble())+"\n");
+        output.append("MacroRecall: " +String.format("%1.4f",macroRecallScores.stream().mapToDouble(var -> var).average().getAsDouble())+"\n");
         output.append("MacroF1: " +String.format("%1.4f",macroF1Scores.stream().mapToDouble(var -> var).average().getAsDouble())+"\n");
 
         //System.out.println("MacroP=" +String.format("%1.4f",macroPrecisionScores.stream().mapToDouble(var -> var).average().getAsDouble()));

--- a/src/main/java/au/com/nicta/csp/brateval/CompareRelations.java
+++ b/src/main/java/au/com/nicta/csp/brateval/CompareRelations.java
@@ -324,9 +324,9 @@ public class CompareRelations
                 if (nextLine.length == 9  && !nextLine[0].equals("type")){
                     if(nextLine[0].equals("all")){
 
-                        output.append("MicroPrecision: " +nextLine[precisionPos] +"\n");
-                        output.append("MicroRecall: " +nextLine[recallPos] +"\n");
-                        output.append("MicroF1: " +nextLine[f1Pos] +"\n");
+                        output.append("Task2bMicroP: " +nextLine[precisionPos] +"\n");
+                        output.append("Task2bMicroR: " +nextLine[recallPos] +"\n");
+                        output.append("Task2bMicroF1: " +nextLine[f1Pos] +"\n");
 
                         //System.out.println("MicroP=" +nextLine[precisionPos]);
                         //System.out.println("MicroR=" +nextLine[recallPos]);
@@ -343,9 +343,9 @@ public class CompareRelations
             }
         }
 
-        output.append("MacroPrecision: " +String.format("%1.4f",macroPrecisionScores.stream().mapToDouble(var -> var).average().getAsDouble()) +"\n");
-        output.append("MacroRecall: " +String.format("%1.4f",macroRecallScores.stream().mapToDouble(var -> var).average().getAsDouble())+"\n");
-        output.append("MacroF1: " +String.format("%1.4f",macroF1Scores.stream().mapToDouble(var -> var).average().getAsDouble())+"\n");
+        output.append("Task2bMacroP: " +String.format("%1.4f",macroPrecisionScores.stream().mapToDouble(var -> var).average().getAsDouble()) +"\n");
+        output.append("Task2bMacroR: " +String.format("%1.4f",macroRecallScores.stream().mapToDouble(var -> var).average().getAsDouble())+"\n");
+        output.append("Task2bMacroF1: " +String.format("%1.4f",macroF1Scores.stream().mapToDouble(var -> var).average().getAsDouble())+"\n");
 
         //System.out.println("MacroP=" +String.format("%1.4f",macroPrecisionScores.stream().mapToDouble(var -> var).average().getAsDouble()));
         //System.out.println("MacroR=" +String.format("%1.4f",macroRecallScores.stream().mapToDouble(var -> var).average().getAsDouble()));

--- a/src/main/java/au/com/nicta/csp/brateval/CompareRelations.java
+++ b/src/main/java/au/com/nicta/csp/brateval/CompareRelations.java
@@ -46,14 +46,14 @@ public class CompareRelations
         { f_measure = (2*precision*recall)/(double)(precision+recall); }
 
         System.out.println(rt
-                + "|tp:" + TP
-                + "|fp:" + FP
-                + "|fn:" + FN
-                + "|precision:" + String.format("%1.4f", precision)
-                + "|recall:" + String.format("%1.4f", recall)
-                + "|f1:" + String.format("%1.4f", f_measure)
-                + "|fpm:" + MFP
-                + "|fnm:" + MFN
+                + "," + TP
+                + "," + FP
+                + "," + FN
+                + "," + String.format("%1.4f", precision)
+                + "," + String.format("%1.4f", recall)
+                + "," + String.format("%1.4f", f_measure)
+                + "," + MFP
+                + "," + MFN
         );
     }
 
@@ -216,6 +216,7 @@ public class CompareRelations
         }
 
         System.out.println("Summary:");
+        System.out.println("type,tp,fp,fn,precision,recall,f1,fpm,fnm");
 
         taxonomy.traverseRelations(new HierList.Visitor<TaxonomyConfig.RelationDesc>() {
             public void pre(int level, TaxonomyConfig.RelationDesc curr,

--- a/src/main/java/au/com/nicta/csp/brateval/Options.java
+++ b/src/main/java/au/com/nicta/csp/brateval/Options.java
@@ -32,6 +32,7 @@ import java.lang.IllegalArgumentException;
 	public String goldFolder; // name of folder for gold standard annotations
 	public String evalFolder; // name of folder for annotations to be compared to gold standard
 	public String configFile; // location/name of annotation.conf file (path + name) [by default, "annotation.conf" in the current directory will be used]
+	public String outputFolder;
      
 	// options related to matching
 	public MatchType matchType; // specify how spans are treated for matching
@@ -50,6 +51,7 @@ import java.lang.IllegalArgumentException;
 		goldFolder = null;
 		evalFolder = null;
 		configFile = "annotation.conf";
+		outputFolder="";
 
 		for (int j=0; j<argv.length; ++j) {
 			if (argv[j].charAt(0) == '-') {
@@ -98,6 +100,10 @@ import java.lang.IllegalArgumentException;
 						if (typeSelection.equalsIgnoreCase("hier"))
 							typeSelection = "HIERARCHICAL";
 						matchType.setTypeMatchType(TypeMatch.valueOf(toEnumName(typeSelection)));
+						break;
+					case "-o" : case "-outputfolder":
+						j++;
+						outputFolder = argv[j];
 						break;
 					default:
 						throw new IllegalArgumentException("Unsupported option" + argv[j]);

--- a/src/main/java/au/com/nicta/csp/brateval/Options.java
+++ b/src/main/java/au/com/nicta/csp/brateval/Options.java
@@ -26,7 +26,7 @@ import java.lang.IllegalArgumentException;
 	}
 
 		
-	public OutFmt outFmt = OutFmt.PLAIN;
+	public OutFmt outFmt = OutFmt.CSV;
 
 	// options related to annotation folders
 	public String goldFolder; // name of folder for gold standard annotations

--- a/src/test/java/au/com/nicta/csp/brateval/CompareEntitiesTest.java
+++ b/src/test/java/au/com/nicta/csp/brateval/CompareEntitiesTest.java
@@ -7,6 +7,7 @@ import java.io.PrintStream;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Locale;
 
 class CompareEntitiesTest {
 
@@ -36,6 +37,7 @@ class CompareEntitiesTest {
 
     @BeforeEach
      void setUp() throws URISyntaxException {
+        Locale.setDefault(new Locale("en", "US")); //Reported scores use "." as decimal seperator
         dataDir = Paths.get(this.getClass().getClassLoader().getResource("data").toURI()).toString();
         GOLD_PATH = getPath(dataDir,"corpora","chemu_sample");
         BRATEVAL_PATH = getPath(dataDir,"bratevals","chemu_sample");

--- a/src/test/java/au/com/nicta/csp/brateval/CompareRelationsTest.java
+++ b/src/test/java/au/com/nicta/csp/brateval/CompareRelationsTest.java
@@ -7,6 +7,7 @@ import java.io.PrintStream;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Locale;
 
 import static au.com.nicta.csp.brateval.CompareEntitiesTest.buildBratEvalFileName;
 import static au.com.nicta.csp.brateval.CompareEntitiesTest.getPath;
@@ -39,6 +40,7 @@ class CompareRelationsTest {
 
     @BeforeEach
     void setUp() throws URISyntaxException {
+        Locale.setDefault(new Locale("en", "US")); //Reported scores use "." as decimal seperator
 
         dataDir = Paths.get(this.getClass().getClassLoader().getResource("data").toURI()).toString();
 


### PR DESCRIPTION
Unit-tests do not work with German Locale (DE), because scores are here reported as 1,000 instead of 1.000. However, the tests expect English-locale to work, which uses decimal separator. I therefore slightly modified the tests so that the locale is set to EN/US. 

